### PR TITLE
Update Function getChildByName and getChildByTag

### DIFF
--- a/cocos/2d/CCNode.h
+++ b/cocos/2d/CCNode.h
@@ -785,14 +785,13 @@ public:
      * @return a Node with the given tag that can be cast to Type T.
     */
     template <typename T>
-    T getChildByTag(int tag) const { return static_cast<T>(getChildByTag(tag)); }
+    void getChildByTag(int tag,T *&type) const { type = static_cast<T>(getChildByTag(tag)); }
     
     /**
      * Gets a child from the container with its name.
      *
-     * @param name   An identifier to find the child node.
-     *
-     * @return a Node object whose name equals to the input parameter.
+     * @param tag   An identifier to find the child node.
+     * @param type  A pointer to Node(Sprite,Button,etc.) that you are seek for.
      *
      * @since v3.2
      */
@@ -805,7 +804,7 @@ public:
      * @return a Node with the given name that can be cast to Type T.
     */
     template <typename T>
-    T getChildByName(const std::string& name) const { return static_cast<T>(getChildByName(name)); }
+    void getChildByName(const std::string& name,T *&type) const { type = static_cast<T>(getChildByName(name)); }
     /** Search the children of the receiving node to perform processing for nodes which share a name.
      *
      * @param name The name to search for, supports c++11 regular expression.


### PR DESCRIPTION
元有问题：和getChildByTag为模板函数，但其形参中不带模板参数所声明的类型，因而这种用法有一定的局限性，实际上不能把返回值自动转化为用户想要的类型（用户还是需要自己强制转换）。
如果使其接受一个指定类型的用户用于捕获返回的指针，则用户就可以写出如下代码，比如：
Sprite sptr =nullptr;
getChildByName("Logo Sprite",sptr);
这样使其可用性更强。